### PR TITLE
fix: align save_state output with restore_state and update completion…

### DIFF
--- a/bin/ksession
+++ b/bin/ksession
@@ -26,7 +26,7 @@ save_state() {
 	fi
 	local state_file="$SESSION_DIR/${session_name}.txt"
 
-	kitty @ ls | jq '[.[0].tabs[] | {title: .title, cwd: .windows[0].cwd}]' >"$state_file"
+	kitty @ ls | jq -r '.[0].tabs[] | "\(.title) \(.windows[0].cwd)"' >"$state_file"
 	echo "Kitty state saved to $state_file"
 }
 

--- a/bin/ksession
+++ b/bin/ksession
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define constants for paths
-VERSION="1.1.1"
+VERSION="1.1.2"
 SESSION_DIR="$HOME/.config/ksession/sessions"
 
 # Ensure the session directory exists

--- a/share/bash-completion/completions/ksession
+++ b/share/bash-completion/completions/ksession
@@ -4,10 +4,10 @@ _ksession_completions() {
 	local current prev opts
 	current="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD - 1]}"
-	opts="save restore destroy list -s -r -d -l"
+	opts="save restore destroy list -s -r -d -l -v"
 
 	if [[ -d ~/.config/ksession/sessions ]]; then
-		if [[ "$prev" == "-r" || "$prev" == "restore" ]]; then
+		if [[ "$prev" == "-r" || "$prev" == "restore" || "$prev" == "-v" || "$prev" || "--view" ]]; then
 			COMPREPLY=($(compgen -W "$(ls ~/.config/ksession/sessions/*.txt 2>/dev/null | xargs -n 1 basename | sed 's/\.txt$//')" -- "$current"))
 		else
 			COMPREPLY=($(compgen -W "$opts" -- "$current"))

--- a/share/bash-completion/completions/ksession
+++ b/share/bash-completion/completions/ksession
@@ -4,10 +4,10 @@ _ksession_completions() {
 	local current prev opts
 	current="${COMP_WORDS[COMP_CWORD]}"
 	prev="${COMP_WORDS[COMP_CWORD - 1]}"
-	opts="save restore destroy list -s -r -d -l -v"
+	opts="save restore destroy list version view -s -r -d -l -v"
 
 	if [[ -d ~/.config/ksession/sessions ]]; then
-		if [[ "$prev" == "-r" || "$prev" == "restore" || "$prev" == "-v" || "$prev" || "--view" ]]; then
+		if [[ "$prev" == "-r" || "$prev" == "restore" || "$prev" == "-v" || "$prev" == "view" ]]; then
 			COMPREPLY=($(compgen -W "$(ls ~/.config/ksession/sessions/*.txt 2>/dev/null | xargs -n 1 basename | sed 's/\.txt$//')" -- "$current"))
 		else
 			COMPREPLY=($(compgen -W "$opts" -- "$current"))

--- a/share/man/man1/ksession.1
+++ b/share/man/man1/ksession.1
@@ -1,4 +1,4 @@
-.TH "KSESSION" "1" "October 2024" "1.1.1" "Custom Commands"
+.TH "KSESSION" "1" "January 2025" "1.1.2" "Custom Commands"
 .SH NAME
 ksession \- Save and restore Kitty terminal sessions
 .SH SYNOPSIS


### PR DESCRIPTION
… script

- Fixed save_state to write session files in plain text instead of JSON, ensuring compatibility with restore_state.
- Updated Bash completion script to include the missing 'view' (-v) command.
- Bumped version to 1.1.2.